### PR TITLE
[#4] Ignore Comment Reviews

### DIFF
--- a/lib/mission_control/models/pull_request.rb
+++ b/lib/mission_control/models/pull_request.rb
@@ -31,6 +31,7 @@ module MissionControl::Models
       pr_reviews = github.pull_request_reviews(repo, pr_number, :accept => 'application/vnd.github.v3+json')
 
       last_reviews = {}
+      pr_reviews.reject! { |review| review[:state] == 'COMMENT' }
       pr_reviews.each { |review| last_reviews[review[:user][:login]] = review[:state] }
 
       @approvals = (last_reviews.select { |_key, value| value == 'APPROVED' }).keys

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -62,42 +62,102 @@ describe MissionControl::Models::PullRequest do
       end
     end
 
-    context 'basic' do
-      let(:approvals) do
-        [
-          { :state => 'APPROVED', :user => { :login => 'jperalta' } },
-          { :state => 'APPROVED', :user => { :login => 'asantiago' } }
-        ]
-      end
+    context 'multiple approvals' do
+      context 'approve' do
+        let(:approvals) do
+          [
+            { :state => 'APPROVED', :user => { :login => 'jperalta' } },
+            { :state => 'APPROVED', :user => { :login => 'asantiago' } }
+          ]
+        end
 
-      it 'two approvals' do
-        expect(pull_request.approvals).to eq(%w[jperalta asantiago])
-      end
-    end
-
-    context 'review changed from approved to not approved' do
-      let(:approvals) do
-        [
-          { :state => 'APPROVED', :user => { :login => 'jperalta' } },
-          { :state => 'CHANGES_REQUESTED', :user => { :login => 'jperalta' } }
-        ]
-      end
-
-      it 'no approvals' do
-        expect(pull_request.approvals).to eq([])
+        it 'two approvals' do
+          expect(pull_request.approvals).to eq(%w[jperalta asantiago])
+        end
       end
     end
 
-    context 'review changed from not approved to approved' do
-      let(:approvals) do
-        [
-          { :state => 'CHANGES_REQUESTED', :user => { :login => 'jperalta' } },
-          { :state => 'APPROVED', :user => { :login => 'jperalta' } }
-        ]
+    context 'single approval' do
+      context 'approve, reject' do
+        let(:approvals) do
+          [
+            { :state => 'APPROVED', :user => { :login => 'jperalta' } },
+            { :state => 'CHANGES_REQUESTED', :user => { :login => 'jperalta' } }
+          ]
+        end
+
+        it 'no approvals' do
+          expect(pull_request.approvals).to eq([])
+        end
       end
 
-      it 'one approval' do
-        expect(pull_request.approvals).to eq(['jperalta'])
+      context 'approve, comment' do
+        let(:approvals) do
+          [
+            { :state => 'APPROVED', :user => { :login => 'jperalta' } },
+            { :state => 'COMMENT', :user => { :login => 'jperalta' } }
+          ]
+        end
+
+        it 'one approval' do
+          expect(pull_request.approvals).to eq(['jperalta'])
+        end
+      end
+
+      context 'reject, approve' do
+        let(:approvals) do
+          [
+            { :state => 'CHANGES_REQUESTED', :user => { :login => 'jperalta' } },
+            { :state => 'APPROVED', :user => { :login => 'jperalta' } }
+          ]
+        end
+
+        it 'one approval' do
+          expect(pull_request.approvals).to eq(['jperalta'])
+        end
+      end
+
+      context 'reject, comment' do
+        let(:approvals) do
+          [
+            { :state => 'CHANGES_REQUESTED', :user => { :login => 'jperalta' } },
+            { :state => 'COMMENT', :user => { :login => 'jperalta' } }
+          ]
+        end
+
+        it 'no approvals' do
+          expect(pull_request.approvals).to eq([])
+        end
+      end
+
+      context 'approve, comment, reject, comment' do
+        let(:approvals) do
+          [
+            { :state => 'APPROVED', :user => { :login => 'jperalta' } },
+            { :state => 'COMMENT', :user => { :login => 'jperalta' } },
+            { :state => 'CHANGES_REQUESTED', :user => { :login => 'jperalta' } },
+            { :state => 'COMMENT', :user => { :login => 'jperalta' } }
+          ]
+        end
+
+        it 'no approvals' do
+          expect(pull_request.approvals).to eq([])
+        end
+      end
+
+      context 'reject, comment, approve, comment' do
+        let(:approvals) do
+          [
+            { :state => 'CHANGES_REQUESTED', :user => { :login => 'jperalta' } },
+            { :state => 'COMMENT', :user => { :login => 'jperalta' } },
+            { :state => 'APPROVED', :user => { :login => 'jperalta' } },
+            { :state => 'COMMENT', :user => { :login => 'jperalta' } }
+          ]
+        end
+
+        it 'one approval' do
+          expect(pull_request.approvals).to eq(['jperalta'])
+        end
       end
     end
   end


### PR DESCRIPTION
If a user approves a PR and adds another review (of type comment). Github treats this is still
approved and we should honor/match this functionality here.

Now, if you approve and then comment, approval will still count
Also, if you request changes and then comment, request changes still applies