### PR TITLE
Improve GitHub Status Check Description

### DIFF
--- a/lib/mission_control/models/control.rb
+++ b/lib/mission_control/models/control.rb
@@ -55,8 +55,8 @@ module MissionControl::Models
       approvals = (pull_request.approvals & users)
 
       state = approvals.length < count ? 'pending' : 'success'
-      description = "#{approvals.length} of #{count}"
-      description += " (#{approvals.join(', ')})" unless approvals.empty?
+      description = "Required: #{count}"
+      description += " | Approved by: #{approvals.join(', ')}" unless approvals.empty?
 
       pull_request.status(state: state, name: name, description: description)
     end

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -153,7 +153,12 @@ describe MissionControl::Models::Control do
         it 'set control approved in github' do
           allow(pull_request).to receive(:approvals).and_return(['aterris'])
 
-          expect(pull_request).to receive(:status).with(state: 'success', name: name, description: '1 of 1 (aterris)')
+          expect(pull_request).to receive(:status).with(
+            state: 'success',
+            name: name,
+            description: 'Required: 1 | Approved by: aterris'
+          )
+
           control.execute!
         end
       end
@@ -162,7 +167,12 @@ describe MissionControl::Models::Control do
         it 'set control pending in github' do
           allow(pull_request).to receive(:approvals).and_return(['jperalta'])
 
-          expect(pull_request).to receive(:status).with(state: 'pending', name: name, description: '0 of 1')
+          expect(pull_request).to receive(:status).with(
+            state: 'pending',
+            name: name,
+            description: 'Required: 1'
+          )
+
           control.execute!
         end
       end
@@ -173,7 +183,12 @@ describe MissionControl::Models::Control do
         it 'set control pending in github' do
           allow(pull_request).to receive(:approvals).and_return(['aterris'])
 
-          expect(pull_request).to receive(:status).with(state: 'pending', name: name, description: '1 of 2 (aterris)')
+          expect(pull_request).to receive(:status).with(
+            state: 'pending',
+            name: name,
+            description: 'Required: 2 | Approved by: aterris'
+          )
+
           control.execute!
         end
       end


### PR DESCRIPTION
The existing description string was confusing users because it was not clear if it was indicating
an approval or a required approval. This change should make it more explicit and easier to
understand