### PR TITLE
[CAL-4564] Dismiss PR Reviews

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,8 +25,5 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Max: 25
 
-Style/RedundantReturn:
-  Enabled: false
-
 Metrics/ParameterLists:
   Max: 6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,4 +23,10 @@ Metrics/MethodLength:
   Max: 20
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
+
+Style/RedundantReturn:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Max: 6

--- a/config.ru
+++ b/config.ru
@@ -13,6 +13,12 @@ if ENV['AIRBRAKE_PROJECT_ID'] && ENV['AIRBRAKE_API_KEY']
   end
 end
 
+configure :test, :development do
+  logger = Logger.new(STDOUT)
+  logger.level = Logger::DEBUG
+  use Rack::CommonLogger, logger
+end
+
 # sync stdout so puts shows in heroku logs
 $stdout.sync = true
 

--- a/example/.mission-control.yaml
+++ b/example/.mission-control.yaml
@@ -4,6 +4,12 @@
     users:
       - cboyle
       - jperalta
+    dismissal_paths:
+        - '*'
+        - '!README.md'
+        - '!spec/'
+        - '!.rspec'
+        - '!.gitignore'
 - qa_review:
     name: 'QA Review'
     users:

--- a/lib/mission_control.rb
+++ b/lib/mission_control.rb
@@ -2,6 +2,7 @@ require 'bundler'
 Bundler.require(:default)
 require 'active_support/all'
 require 'yaml'
+require 'logger'
 
 Dotenv.load
 

--- a/lib/mission_control.rb
+++ b/lib/mission_control.rb
@@ -3,6 +3,7 @@ Bundler.require(:default)
 require 'active_support/all'
 require 'yaml'
 require 'logger'
+require 'pry'
 
 Dotenv.load
 

--- a/lib/mission_control/models/control.rb
+++ b/lib/mission_control/models/control.rb
@@ -9,8 +9,6 @@ module MissionControl::Models
       )
 
       return if response.nil? || response[:content].nil?
-      return if pull_request.update_with_master?
-
       controls = YAML.safe_load(Base64.decode64(response[:content]))
 
       controls.map do |control|
@@ -28,6 +26,8 @@ module MissionControl::Models
 
     def self.execute!(pull_request:)
       controls = Control.fetch(pull_request: pull_request)
+      return unless controls
+      return if pull_request.update_with_master?
 
       control_description = "repo: #{pull_request.repo} base_branch: #{pull_request.base_branch}"
       puts "Executing #{controls.length} Controls | #{control_description} | PR: #{pull_request.pr_number}"

--- a/lib/mission_control/models/control.rb
+++ b/lib/mission_control/models/control.rb
@@ -35,7 +35,7 @@ module MissionControl::Models
 
     attr_accessor :pull_request, :name, :users, :paths, :count, :dismissal_paths
 
-    def initialize(pull_request:, name:, users:, paths: '*', count: 1, dismissal_paths: '*')
+    def initialize(pull_request:, name:, users:, paths: '*', count: 1, dismissal_paths: nil)
       @pull_request = pull_request
       @name = name
       @users = users
@@ -45,7 +45,7 @@ module MissionControl::Models
     end
 
     def active?
-      !PathSpec.from_lines(@paths).match_paths(pull_request.files).empty?
+      PathSpec.from_lines(@paths).match_paths(pull_request.files).any?
     end
 
     def execute!
@@ -53,7 +53,7 @@ module MissionControl::Models
     end
 
     def dismissable?
-      !PathSpec.from_lines(@dismissal_paths).match_paths(pull_request.changed_files).empty?
+      PathSpec.from_lines(@dismissal_paths).match_paths(pull_request.changed_files).any?
     end
 
     def dismiss_reviews!

--- a/lib/mission_control/models/control.rb
+++ b/lib/mission_control/models/control.rb
@@ -18,7 +18,8 @@ module MissionControl::Models
           name: control['name'],
           users: control['users'],
           paths: control['paths'],
-          count: control['count']
+          count: control['count'],
+          dismissal_paths: control['dismissal_paths']
         )
       end
     end
@@ -28,17 +29,19 @@ module MissionControl::Models
 
       control_description = "repo: #{pull_request.repo} base_branch: #{pull_request.base_branch}"
       puts "Executing #{controls.length} Controls | #{control_description} | PR: #{pull_request.pr_number}"
+      controls.each(&:dismiss_reviews!)
       controls.each(&:execute!)
     end
 
-    attr_accessor :pull_request, :name, :users, :paths, :count
+    attr_accessor :pull_request, :name, :users, :paths, :count, :dismissal_paths
 
-    def initialize(pull_request:, name:, users:, paths: '*', count: 1)
+    def initialize(pull_request:, name:, users:, paths: '*', count: 1, dismissal_paths: '*')
       @pull_request = pull_request
       @name = name
       @users = users
       @paths = paths || '*'
       @count = count || 1
+      @dismissal_paths = dismissal_paths || @paths
     end
 
     def active?
@@ -47,6 +50,14 @@ module MissionControl::Models
 
     def execute!
       active? ? execute_active! : execute_inactive!
+    end
+
+    def dismissable?
+      !PathSpec.from_lines(@dismissal_paths).match_paths(pull_request.changed_files).empty?
+    end
+
+    def dismiss_reviews!
+      execute_dismissals! if dismissable?
     end
 
     private
@@ -63,6 +74,14 @@ module MissionControl::Models
 
     def execute_inactive!
       pull_request.status(state: 'success', name: name, description: 'Not Required')
+    end
+
+    def execute_dismissals!
+      dismissals = pull_request.approved_reviews.select do |review|
+        users.include? review[:user][:login]
+      end
+
+      pull_request.dismiss(dismissals) unless dismissals.empty?
     end
   end
 end

--- a/lib/mission_control/models/control.rb
+++ b/lib/mission_control/models/control.rb
@@ -8,7 +8,9 @@ module MissionControl::Models
         :ref => pull_request.base_branch
       )
 
-      return if response.nil? && response[:content].nil?
+      return if response.nil? || response[:content].nil?
+      return if pull_request.update_with_master?
+
       controls = YAML.safe_load(Base64.decode64(response[:content]))
 
       controls.map do |control|

--- a/lib/mission_control/models/control.rb
+++ b/lib/mission_control/models/control.rb
@@ -19,7 +19,8 @@ module MissionControl::Models
           users: control['users'],
           paths: control['paths'],
           count: control['count'],
-          dismissal_paths: control['dismissal_paths']
+          dismissal_paths: control['dismissal_paths'],
+          dismiss_enabled: control['dismiss']
         )
       end
     end
@@ -35,15 +36,16 @@ module MissionControl::Models
       controls.each(&:execute!)
     end
 
-    attr_accessor :pull_request, :name, :users, :paths, :count, :dismissal_paths
+    attr_accessor :pull_request, :name, :users, :paths, :count, :dismissal_paths, :dismiss_enabled
 
-    def initialize(pull_request:, name:, users:, paths: '*', count: 1, dismissal_paths: nil)
+    def initialize(pull_request:, **args)
       @pull_request = pull_request
-      @name = name
-      @users = users
-      @paths = paths || '*'
-      @count = count || 1
-      @dismissal_paths = dismissal_paths || @paths
+      @name = args[:name]
+      @users = args[:users]
+      @paths = args[:paths] || '*'
+      @count = args[:count] || 1
+      @dismissal_paths = args[:dismissal_paths] || @paths
+      @dismiss_enabled = args[:dismiss_enabled].nil? || args[:dismiss_enabled]
     end
 
     def active?
@@ -55,6 +57,7 @@ module MissionControl::Models
     end
 
     def dismissable?
+      return false unless dismiss_enabled
       PathSpec.from_lines(@dismissal_paths).match_paths(pull_request.changed_files).any?
     end
 

--- a/lib/mission_control/models/pull_request.rb
+++ b/lib/mission_control/models/pull_request.rb
@@ -16,35 +16,71 @@ module MissionControl::Models
       @payload['pull_request']['number']
     end
 
-    def commit
+    def last_commit
       @payload['pull_request']['head']['sha']
+    end
+
+    def commits
+      @commits ||= github.pull_request_commits(repo, pr_number, :accept => 'application/vnd.github.v3+json')
     end
 
     def base_branch
       @payload['pull_request']['base']['ref']
     end
 
+    def reviews
+      @reviews ||= github.pull_request_reviews(repo, pr_number, :accept => 'application/vnd.github.v3+json')
+    end
+
     # Functionality
+    def approved_reviews
+      return @approved_reviews unless @approved_reviews.nil?
+      @approved_reviews = reviews
+                          .reject { |review| review[:state] == 'COMMENTED' }
+                          .reverse.uniq { |review| review[:user][:login] }.reverse
+                          .select { |review| review[:state] == 'APPROVED' }
+    end
+
     def approvals
       return @approvals unless @approvals.nil?
-
-      pr_reviews = github.pull_request_reviews(repo, pr_number, :accept => 'application/vnd.github.v3+json')
-
-      last_reviews = {}
-      pr_reviews.reject! { |review| review[:state] == 'COMMENTED' }
-      pr_reviews.each { |review| last_reviews[review[:user][:login]] = review[:state] }
-
-      @approvals = (last_reviews.select { |_key, value| value == 'APPROVED' }).keys
+      @approvals = approved_reviews.map { |review| review[:user][:login] }
     end
 
     def files
       @files ||= github.pull_files(repo, pr_number).map { |file| "/#{file[:filename]}" }
     end
 
+    def new_commits
+      return @new_commits unless @new_commits.nil?
+
+      @new_commits =
+        if reviews.empty?
+          commits
+        else
+          commits.reject do |commit|
+            commit[:commit][:committer][:date] < reviews.last[:submitted_at]
+          end
+        end
+    end
+
+    def changed_files
+      return @changed_files unless @changed_files.nil?
+
+      new_commits.map do |commit|
+        github.commit(repo, commit[:sha])[:files].map { |file| "/#{file[:filename]}" }
+      end.flatten.uniq
+    end
+
     def status(state:, name:, description:)
-      github.create_status(repo, commit, state,
+      github.create_status(repo, last_commit, state,
                            context: "mission-control/#{name.parameterize}",
                            description: description)
+    end
+
+    def dismiss(reviews)
+      reviews.each do |review|
+        github.dismiss_pull_request_review(repo, pr_number, review[:id], 'Dismissed by Mission Control')
+      end
     end
 
     private

--- a/lib/mission_control/models/pull_request.rb
+++ b/lib/mission_control/models/pull_request.rb
@@ -48,7 +48,7 @@ module MissionControl::Models
 
       return false unless parent_commit_shas.count == 2
       return false unless parent_commit_shas.include?(last_base_branch_commit[:sha])
-      return true
+      true
     end
 
     def approved_reviews

--- a/lib/mission_control/models/pull_request.rb
+++ b/lib/mission_control/models/pull_request.rb
@@ -49,16 +49,13 @@ module MissionControl::Models
     end
 
     def new_commits
-      return @new_commits unless @new_commits.nil?
+      return commits if reviews.empty?
 
-      @new_commits =
-        if reviews.empty?
-          commits
-        else
-          commits.reject do |commit|
-            commit[:commit][:committer][:date] < reviews.last[:submitted_at]
-          end
-        end
+      index = commits.find_index do |commit|
+        commit[:sha] == reviews.last[:commit_id]
+      end
+
+      index.nil? ? commits : commits[index + 1..-1]
     end
 
     def changed_files
@@ -80,7 +77,7 @@ module MissionControl::Models
         github.dismiss_pull_request_review(repo, pr_number, review[:id], 'Dismissed by Mission Control')
       end
 
-      @reviews = github.pull_request_reviews(repo, pr_number, :accept => 'application/vnd.github.v3+json')
+      @reviews = nil
     end
 
     private

--- a/lib/mission_control/models/pull_request.rb
+++ b/lib/mission_control/models/pull_request.rb
@@ -34,16 +34,14 @@ module MissionControl::Models
 
     # Functionality
     def approved_reviews
-      return @approved_reviews unless @approved_reviews.nil?
-      @approved_reviews = reviews
-                          .reject { |review| review[:state] == 'COMMENTED' }
-                          .reverse.uniq { |review| review[:user][:login] }.reverse
-                          .select { |review| review[:state] == 'APPROVED' }
+      reviews
+        .reject { |review| review[:state] == 'COMMENTED' }
+        .reverse.uniq { |review| review[:user][:login] }.reverse
+        .select { |review| review[:state] == 'APPROVED' }
     end
 
     def approvals
-      return @approvals unless @approvals.nil?
-      @approvals = approved_reviews.map { |review| review[:user][:login] }
+      approved_reviews.map { |review| review[:user][:login] }
     end
 
     def files
@@ -81,6 +79,8 @@ module MissionControl::Models
       reviews.each do |review|
         github.dismiss_pull_request_review(repo, pr_number, review[:id], 'Dismissed by Mission Control')
       end
+
+      @reviews = github.pull_request_reviews(repo, pr_number, :accept => 'application/vnd.github.v3+json')
     end
 
     private

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -39,6 +39,7 @@ describe MissionControl::Models::Control do
   let(:paths) { '*' }
   let(:count) { 1 }
   let(:dismissal_paths) { '*' }
+  let(:dismiss) { nil }
 
   let(:control) do
     MissionControl::Models::Control.new(
@@ -47,7 +48,8 @@ describe MissionControl::Models::Control do
       users: users,
       paths: paths,
       count: count,
-      dismissal_paths: dismissal_paths
+      dismissal_paths: dismissal_paths,
+      dismiss_enabled: dismiss
     )
   end
 
@@ -136,6 +138,19 @@ describe MissionControl::Models::Control do
     let(:dismissal_paths) { nil }
     it 'dismissal path defaults to paths' do
       expect(control.dismissal_paths).to eq(paths)
+    end
+
+    context 'dismiss control not set' do
+      it 'defaults to true' do
+        expect(control.dismiss_enabled).to be true
+      end
+    end
+
+    context 'dismiss control set to false' do
+      let(:dismiss) { false }
+      it 'set to false' do
+        expect(control.dismiss_enabled).to be false
+      end
     end
   end
 
@@ -242,6 +257,12 @@ describe MissionControl::Models::Control do
   end
 
   describe '#dismissable?' do
+    context 'dismiss control set to false' do
+      let(:dismiss) { false }
+      it 'not dismissable' do
+        expect(control.dismissable?).to eq false
+      end
+    end
     context 'all paths' do
       it 'dismissable' do
         allow(pull_request).to receive(:changed_files).and_return(['/lib/mission_control.rb'])

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -106,6 +106,13 @@ describe MissionControl::Models::Control do
     end
   end
 
+  describe '#initialize' do
+    let(:dismissal_paths) { nil }
+    it 'dismissal path defaults to paths' do
+      expect(control.dismissal_paths).to eq(paths)
+    end
+  end
+
   describe '#active?' do
     context 'all paths' do
       let(:paths) { '*' }

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -58,11 +58,21 @@ describe MissionControl::Models::Control do
 
       config_file = File.read('spec/fixtures/.mission-control.yml')
       allow(github_stub).to receive(:content).and_return(:content => Base64.encode64(config_file))
+      allow(pull_request).to receive(:update_with_master?).and_return(false)
     end
 
     it 'skip if no config file found in the repo' do
       allow(github_stub).to receive(:content).and_return(nil)
       expect(MissionControl::Models::Control).to_not receive(:new)
+
+      MissionControl::Models::Control.fetch(pull_request: pull_request)
+    end
+
+    it 'skip if pull request is an update to master' do
+      allow(pull_request).to receive(:update_with_master?).and_return(true)
+      expect(MissionControl::Models::Control).to_not receive(:new)
+
+      MissionControl::Models::Control.fetch(pull_request: pull_request)
     end
 
     it 'fetches controls from repo' do

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -41,9 +41,9 @@ describe MissionControl::Models::PullRequest do
     end
   end
 
-  describe '#commit' do
+  describe '#last_commit' do
     specify do
-      expect(pull_request.commit).to eq('abc123')
+      expect(pull_request.last_commit).to eq('abc123')
     end
   end
 


### PR DESCRIPTION
## Changes
- added common logging to observe requests
- add functionality to dismiss prs based on either paths or dismissal paths set in the mission_control.yml file of a repo.
  - Dismissals will only occur if new commits taken place after the last review (or all commits if no reviews) match the paths as defined in the control's dismissal paths or paths if no dismissal path is defined

  

## QA:
Using https://github.com/calendly/git_playground repo:
- [x] create a pr add yourself to review (make sure you either belong to the code review or qa review control in the https://github.com/calendly/git_playground/blob/master/.mission-control.yml)
- [x] Approve the pr and confirm that Mission Control status updates correctly (for Code Review, should only show 1 pending, for QA status should be complete)
- [x] Create a new commit that doesnt match the paths declared in dismissal paths or the path of the control you belong to
- [x] Confirm that your review has been dismissed by Mission Control and that the Mission Control status is updated correctly
---
- [x] Do the same steps as above execpt this time on the new commit, change a file that matches the dismissal path or paths if dismissal path is not defined
- [x] Confirm that your review is not dismissed for the new review
