### PR TITLE
add spec for matching subdirectory

### DIFF
--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -118,15 +118,20 @@ describe MissionControl::Models::Control do
     end
 
     context 'ignored directory' do
-      let(:paths) { ['*', '!specs/'] }
+      let(:paths) { ['*', '!specs/', '!deployment/**'] }
 
       it 'active' do
         allow(pull_request).to receive(:files).and_return(['/lib/mission_control.rb'])
         expect(control.active?).to be true
       end
 
+      it 'active for subdirectory that contains part of an ignored path' do
+        allow(pull_request).to receive(:files).and_return(['/services/deployment/service_object.rb'])
+        expect(control.active?).to be true
+      end
+
       it 'inactive' do
-        allow(pull_request).to receive(:files).and_return(['/specs/mission_control_spec.rb'])
+        allow(pull_request).to receive(:files).and_return(['/specs/mission_control_spec.rb', '/deployment/initializer.rb'])
         expect(control.active?).to be false
       end
     end


### PR DESCRIPTION
This PR adds a test that verifies a proposed change for how we go about ignoring directories.  There was a bug we found related to an ignored path being contained an a sub directory that was being ignored unintentionally.

The example behavior is as follows:
```yml
- qa_review:
    name: 'QA Review'
    users:
      - asantiago
      - tjeffords
    paths:
      - '*'
      - '!README.md'
      - '!spec/'
      - '!.rspec'
     -  '!deployment/'
```
The way deployment is being configured is too broad in scope and will cause mission control to ignore sub directories that also contain `deployment` in their path.  For example, if we added a file to a pull request that had the path `services/deployment/service_object.rb` it would not trigger a QA review in mission control.

Alternatively, my proposed change (verified via a test) would be to do the following instead:
```yml
- qa_review:
    name: 'QA Review'
    users:
      - asantiago
      - tjeffords
    paths:
      - '*'
      - '!README.md'
      - '!spec/'
      - '!.rspec'
     -  '!deployment/**'
```

This will ignore all of the contents [to an infinite depth](https://git-scm.com/docs/gitignore) of the deployment directory, rather than any directory that contains `deployment` in its path.